### PR TITLE
Use the same device identifier in sensor and switch

### DIFF
--- a/custom_components/tessie/switch.py
+++ b/custom_components/tessie/switch.py
@@ -225,7 +225,7 @@ class TessieSwitchBase(CoordinatorEntity, SwitchEntity, ABC):
     def device_info(self) -> DeviceInfo:
         """Return the device info for the switch."""
         return DeviceInfo(
-            identifiers={(DOMAIN, MANUFACTURER)},
+            identifiers={(DOMAIN, self._name)},
             name=self._name,
             manufacturer=MANUFACTURER,
             model=self._model,


### PR DESCRIPTION
You should create a BaseTessie class to set this, and then extend that to Sensor and Switch, but for now this is a simple fix to avoid having it create two devices.